### PR TITLE
feat: Switch back to `pull_request`. Update version instead.

### DIFF
--- a/.github/workflows/target.yml
+++ b/.github/workflows/target.yml
@@ -1,6 +1,6 @@
 name: "PR Audit"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/target.yml
+++ b/.github/workflows/target.yml
@@ -15,6 +15,6 @@ jobs:
   semantics:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v1.2.0
+      - uses: amannn/action-semantic-pull-request@v3.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updating the version of the github action allows it to also work on `pull_request`.
I think you would just have to manually approve the action run, so that I could not include a bitcoin mining script in the changes.

I think this is a little bit safer than simply switching to `pull_request_target` :D 


Have a look at the PR from my other account @intrigus
https://github.com/intrigus-lgtm/mouthpiece/pull/2 and the working action run:
https://github.com/intrigus-lgtm/mouthpiece/pull/2/checks?check_run_id=3129104528